### PR TITLE
Added Header, Menu and UserCard

### DIFF
--- a/app/components/general/menu.tsx
+++ b/app/components/general/menu.tsx
@@ -1,0 +1,92 @@
+import Link from "next/link";
+import React from "react";
+import { Button } from "antd";
+
+/**
+ * Represents a single item within a menu.
+ *
+ * A {@link MenuItem} can be used to define a navigation item or a button action within a menu.
+ * It provides optional properties for specifying a navigation link, an onClick handler,
+ * and a subview which can be used to render additional content such as tags.
+ *
+ * @property label - The text displayed for the menu item.
+ * @property link - `Optional` An URL that the menu item navigates to when clicked.
+ * @property onClick - `Optional` A callback function that handles click events on the menu item.
+ * @property subview - `Optional` A React node that represents an additional view or nested menu.
+ *
+ * A menu item must have either a link or an onClick handler defined.
+ */
+export type MenuItem = {
+  label: string;
+  link?: string;
+  onClick?: () => void;
+  subview?: React.ReactNode;
+};
+
+const MenuItem: React.FC<MenuItem> = ({
+  label,
+  link,
+  onClick,
+  subview,
+}: MenuItem): React.ReactElement => {
+  return (
+    <li>
+      {link ? (
+        <Button type="link">
+          <Link
+            href={link}
+            style={{ display: "flex", gap: 8, alignItems: "center" }}
+          >
+            {label}
+            {subview ? subview : ""}
+          </Link>
+        </Button>
+      ) : onClick ? (
+        <Button type="link" onClick={onClick}>
+          {label}
+        </Button>
+      ) : (
+        (() => {
+          throw new Error(
+            "MenuItem must have either its link or onClick attribute set."
+          );
+        })()
+      )}
+    </li>
+  );
+};
+
+/**
+ * Creates a menu.
+ *
+ * @property items - An array of {@link MenuItem}.
+ * @property horizontal - `Optional` Flag indicating if the menu is displayed horizontally.
+ */
+export type Menu = {
+  items: MenuItem[];
+  horizontal?: boolean;
+};
+
+const Menu: React.FC<Menu> = ({ items, horizontal }) => {
+  return (
+    <ul
+      style={{
+        display: "flex",
+        flexDirection: horizontal ? "row" : "column",
+        listStyle: "none",
+      }}
+    >
+      {items.map((item, index) => (
+        <MenuItem
+          key={index}
+          link={item.link}
+          label={item.label}
+          onClick={item.onClick}
+          subview={item.subview}
+        />
+      ))}
+    </ul>
+  );
+};
+
+export default Menu;

--- a/app/components/general/menu.tsx
+++ b/app/components/general/menu.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import React from "react";
 import { Button } from "antd";
 
@@ -13,15 +12,13 @@ import { Button } from "antd";
  * @property link - `Optional` An URL that the menu item navigates to when clicked.
  * @property onClick - `Optional` A callback function that handles click events on the menu item.
  * @property subview - `Optional` A React node that represents an additional view or nested menu.
- *
- * A menu item must have either a link or an onClick handler defined.
  */
-export type MenuItem = {
+export interface MenuItem {
   label: string;
   link?: string;
   onClick?: () => void;
   subview?: React.ReactNode;
-};
+}
 
 const MenuItem: React.FC<MenuItem> = ({
   label,
@@ -29,29 +26,26 @@ const MenuItem: React.FC<MenuItem> = ({
   onClick,
   subview,
 }: MenuItem): React.ReactElement => {
+  // If a link is provided, set href to the link
+  // If an onClick handler is provided, set onClick to the handler
   return (
-    <li>
-      {link ? (
-        <Button type="link">
-          <Link
-            href={link}
-            style={{ display: "flex", gap: 8, alignItems: "center" }}
-          >
-            {label}
-            {subview ? subview : ""}
-          </Link>
-        </Button>
-      ) : onClick ? (
-        <Button type="link" onClick={onClick}>
-          {label}
-        </Button>
-      ) : (
-        (() => {
-          throw new Error(
-            "MenuItem must have either its link or onClick attribute set."
-          );
-        })()
-      )}
+    <li style={{ listStyle: "none" }}>
+      <Button
+        type="link"
+        href={link ? link : undefined}
+        onClick={onClick ? onClick : undefined}
+        style={{
+          margin: 0,
+          padding: 8,
+          height: "fit-content",
+          display: "flex",
+          gap: 8,
+          alignItems: "center",
+        }}
+      >
+        {label}
+        {subview ? subview : ""}
+      </Button>
     </li>
   );
 };
@@ -73,6 +67,8 @@ const Menu: React.FC<Menu> = ({ items, horizontal }) => {
       style={{
         display: "flex",
         flexDirection: horizontal ? "row" : "column",
+        gap: horizontal ? 16 : 2,
+        alignItems: "flex-start",
         listStyle: "none",
       }}
     >

--- a/app/components/general/usercard.tsx
+++ b/app/components/general/usercard.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { Avatar, Card, Flex, Tag } from "antd";
+import { UserOutlined } from "@ant-design/icons";
+
+/**
+ * Represents the properties for the UserCard component.
+ *
+ * @property username - The username to be displayed by the UserCard.
+ * @property rank - The rank associated with the user.
+ * @property subview - `Optional` A React node for rendering any additional subview content, ex. a button that shows more options.
+ */
+interface UserCardProps {
+  username: string;
+  rank: string;
+  subview?: React.ReactNode;
+}
+
+/**
+ * A reusable card component that displays a user's information.
+ *
+ * This component renders a card with a default avatar (for now), username, and rank.
+ * It also supports an optional subview element that can be rendered alongside the main user information.
+ *
+ * @property username - The username to be displayed by the UserCard.
+ * @property rank - The rank associated with the user.
+ * @property subview - `Optional` A React node for rendering any additional subview content, ex. a button that shows more options.
+ *
+ * @returns A React element representing the user card.
+ */
+const UserCard: React.FC<
+  UserCardProps & React.HTMLAttributes<HTMLSpanElement> // Extend the props for the component to work with antd <Popover>
+> = ({ username, rank, subview, ...props }): React.ReactElement => {
+  return (
+    <Card {...props} size="small" hoverable>
+      <Flex gap={32} align="center">
+        <Flex gap={16}>
+          <Avatar size={42} icon={<UserOutlined />} />
+          <Flex vertical align="start">
+            <p>{username}</p>
+            <Tag color="purple">{rank}</Tag>
+          </Flex>
+        </Flex>
+        {subview ? subview : ""}
+      </Flex>
+    </Card>
+  );
+};
+
+export default UserCard;

--- a/app/components/general/usercard.tsx
+++ b/app/components/general/usercard.tsx
@@ -3,41 +3,67 @@ import { Avatar, Card, Flex, Tag } from "antd";
 import { UserOutlined } from "@ant-design/icons";
 
 /**
- * Represents the properties for the UserCard component.
+ * Properties for the UserCard component.
  *
- * @property username - The username to be displayed by the UserCard.
- * @property rank - The rank associated with the user.
- * @property subview - `Optional` A React node for rendering any additional subview content, ex. a button that shows more options.
+ * @property username - `Optional` The user's display name.
+ * @property rank - `Optional` The rank of the user.
+ * @property showPointer - `Optional` Determines if the cursor should change to a pointer on hover.
+ * @property onClick - `Optional` Callback fired when the card is clicked.
+ * @property subview - `Optional` React node rendered alongside the main user details.
  */
 interface UserCardProps {
-  username: string;
-  rank: string;
+  username?: string;
+  rank?: string;
+  showPointer?: boolean;
+  onClick?: () => void;
   subview?: React.ReactNode;
 }
 
 /**
- * A reusable card component that displays a user's information.
+ * UserCard component.
  *
- * This component renders a card with a default avatar (for now), username, and rank.
- * It also supports an optional subview element that can be rendered alongside the main user information.
+ * This component renders a compact card displaying a user's avatar, username, and rank.
+ * It supports additional clickable functionality and an optional subview, rendered to the right of the user details.
+ * The card can be styled to change the cursor to a pointer when hovered over.
+ * Leave the username and rank fields unset to render only the avatar.
  *
- * @property username - The username to be displayed by the UserCard.
- * @property rank - The rank associated with the user.
- * @property subview - `Optional` A React node for rendering any additional subview content, ex. a button that shows more options.
+ * @property username - `Optional` The user's display name.
+ * @property rank - `Optional` The rank of the user.
+ * @property showPointer - `Optional` Determines if the cursor should change to a pointer on hover.
+ * @property onClick - `Optional` Callback fired when the card is clicked.
+ * @property subview - `Optional` React node rendered alongside the main user details.
  *
  * @returns A React element representing the user card.
  */
 const UserCard: React.FC<
   UserCardProps & React.HTMLAttributes<HTMLSpanElement> // Extend the props for the component to work with antd <Popover>
-> = ({ username, rank, subview, ...props }): React.ReactElement => {
+> = ({
+  username,
+  rank,
+  showPointer,
+  onClick,
+  subview,
+  ...props
+}): React.ReactElement => {
   return (
-    <Card {...props} size="small" hoverable>
-      <Flex gap={32} align="center">
+    <Card
+      {...props}
+      onClick={onClick ? onClick : undefined}
+      size="small"
+      styles={{
+        body: {
+          height: 72,
+          minWidth: 72,
+          cursor: showPointer ? "pointer" : "default",
+        },
+      }}
+    >
+      <Flex gap={32} align="center" justify="center" style={{ height: "100%" }}>
         <Flex gap={16}>
           <Avatar size={42} icon={<UserOutlined />} />
           <Flex vertical align="start">
-            <p>{username}</p>
-            <Tag color="purple">{rank}</Tag>
+            {username && <p>{username}</p>}
+            {rank && <Tag color="purple">{rank}</Tag>}
           </Flex>
         </Flex>
         {subview ? subview : ""}

--- a/app/components/layout/navigation/header.tsx
+++ b/app/components/layout/navigation/header.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Card, Flex, Popover, Tag } from "antd";
+import { Button, Card, Flex, Popover, Tag } from "antd";
 import { DollarOutlined, DownOutlined } from "@ant-design/icons";
 import Menu, { MenuItem } from "@/components/general/menu";
 import UserCard from "@/components/general/usercard";
+import useLocalStorage from "@/hooks/useLocalStorage";
 
 const appLinks: MenuItem[] = [
   {
@@ -54,15 +55,57 @@ const userLinks: MenuItem[] = [
     label: "Settings",
     link: "/settings",
   },
-  {
-    label: "Sign out",
-    onClick: handleLogout,
-  },
 ];
 
-function handleLogout() {
-  console.log("Sign out");
-}
+const Profile: React.FC = () => {
+  const { value: token, clear: clearToken } = useLocalStorage<string>(
+    "token",
+    ""
+  );
+
+  function handleLogout() {
+    clearToken();
+  }
+
+  // User is logged in
+  if (token) {
+    return (
+      <Popover
+        content={
+          <Menu
+            items={[...userLinks, { label: "Sign out", onClick: handleLogout }]}
+          ></Menu>
+        }
+        trigger="hover"
+        mouseLeaveDelay={0.3}
+      >
+        <UserCard
+          username={"Username"}
+          rank={"Rank"}
+          showPointer
+          subview={<DownOutlined />}
+        ></UserCard>
+      </Popover>
+    );
+  } else {
+    // User is not logged in
+    return (
+      <Flex
+        align="center"
+        justify="center"
+        gap={8}
+        style={{ height: 72, paddingRight: 16 }}
+      >
+        <Button type="primary" href="/register">
+          Register
+        </Button>
+        <Button type="default" href="/login">
+          Login
+        </Button>
+      </Flex>
+    );
+  }
+};
 
 const Header: React.FC = () => {
   return (
@@ -73,17 +116,7 @@ const Header: React.FC = () => {
       >
         <Flex justify="space-between" align="center">
           <Menu items={appLinks} horizontal></Menu>
-          <Popover
-            content={<Menu items={userLinks}></Menu>}
-            trigger="hover"
-            mouseLeaveDelay={0.3}
-          >
-            <UserCard
-              username={"Username"}
-              rank={"Rank"}
-              subview={<DownOutlined />}
-            ></UserCard>
-          </Popover>
+          <Profile></Profile>
         </Flex>
       </Card>
     </nav>

--- a/app/components/layout/navigation/header.tsx
+++ b/app/components/layout/navigation/header.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Card, Flex, Popover, Tag } from "antd";
+import { DollarOutlined, DownOutlined } from "@ant-design/icons";
+import Menu, { MenuItem } from "@/components/general/menu";
+import UserCard from "@/components/general/usercard";
+
+const appLinks: MenuItem[] = [
+  {
+    label: "Home",
+    link: "/",
+  },
+  {
+    label: "Play Casual",
+    link: "/casual",
+  },
+  {
+    label: "Play Competitive",
+    link: "/competitive",
+  },
+  {
+    label: "Leaderboard",
+    link: "/leaderboard",
+  },
+  {
+    label: "Game Rules",
+    link: "/rules",
+  },
+  {
+    label: "Store",
+    link: "/store",
+    subview: (
+      <Tag icon={<DollarOutlined />} color="gold">
+        1000
+      </Tag>
+    ),
+  },
+];
+
+const userLinks: MenuItem[] = [
+  {
+    label: "Profile",
+    link: "/profile",
+  },
+  {
+    label: "Achievements",
+    link: "/achivements",
+  },
+  {
+    label: "Game History",
+    link: "/history",
+  },
+  {
+    label: "Settings",
+    link: "/settings",
+  },
+  {
+    label: "Sign out",
+    onClick: handleLogout,
+  },
+];
+
+function handleLogout() {
+  console.log("Sign out");
+}
+
+const Header: React.FC = () => {
+  return (
+    <nav style={{ padding: 16 }}>
+      <Card
+        styles={{ body: { padding: 4, background: "#f9f9f9" } }}
+        size="small"
+      >
+        <Flex justify="space-between" align="center">
+          <Menu items={appLinks} horizontal></Menu>
+          <Popover
+            content={<Menu items={userLinks}></Menu>}
+            trigger="hover"
+            mouseLeaveDelay={0.3}
+          >
+            <UserCard
+              username={"Username"}
+              rank={"Rank"}
+              subview={<DownOutlined />}
+            ></UserCard>
+          </Popover>
+        </Flex>
+      </Card>
+    </nav>
+  );
+};
+
+export default Header;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { ConfigProvider } from "antd";
 import { AntdRegistry } from "@ant-design/nextjs-registry";
 import "@/styles/globals.css";
+import Header from "@/components/layout/navigation/header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,6 +29,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <ConfigProvider theme={{}}>
+          <Header></Header>
           <AntdRegistry>{children}</AntdRegistry>
         </ConfigProvider>
       </body>


### PR DESCRIPTION
### Related Issues

Closes #107, Closes #108, Closes #100, Closes #111

### Changes

- added a new layout component `Header`, which incorporates a `Menu` for the most common links and a `UserCard` that displays an additional `Menu` with Links and a Button on hover
- created a new general component `Menu`, which creates simple menus containing `MenuItems`, that can have either a link attribute or an onClick attribute
- created a new general component `UserCard`, which can display the username, rank, and an optional subview (ex. buttons that provide user interactions or icons), leave the username and rank unset to render only the icon
- added the header to layout.tsx, so its displayed on all pages (for now)
- the `Profile` component of `header.tsx` shows content based on login state

### Additional Comments
The `UserCard` can be used for the friends menu now, take a look at the comments in `usercard.tsx` for further reference @froeoe 
